### PR TITLE
Fixed issues on including libtirpc on VisIVOImporter and API_LIGHT

### DIFF
--- a/src/API_LIGHT/CMakeLists.txt
+++ b/src/API_LIGHT/CMakeLists.txt
@@ -17,6 +17,11 @@ find_package(CURL REQUIRED)
 find_package(MPI REQUIRED)
 find_package(OpenMP REQUIRED)
 
+find_library(TIRPC_LIBRARIES
+    NAMES tirpc
+)
+
+
 set(API_HEADERS
     visivo.h
     visivodef.h
@@ -217,7 +222,7 @@ target_link_libraries(VisIVOApi PRIVATE
     OpenMP::OpenMP_CXX
     ${VTK_LIBRARIES}
     ${HDF5_LIBRARIES}
-    tirpc
+    ${TIRPC_LIBRARIES}
 )
 
 install(TARGETS VisIVOApi DESTINATION lib)

--- a/src/VisIVOImporter/CMakeLists.txt
+++ b/src/VisIVOImporter/CMakeLists.txt
@@ -116,6 +116,10 @@ find_package(VTK 9.1.0 REQUIRED COMPONENTS
     zlib
 )
 
+find_library(TIRPC_LIBRARIES
+    NAMES tirpc
+)
+
 set(IMPORTER_SOURCE
     Importers/abstractsource.cpp
     Importers/abstractsource.h
@@ -183,7 +187,7 @@ target_link_libraries(VisIVOImporter PRIVATE
     OpenMP::OpenMP_CXX
     ${VTK_LIBRARIES}
     stdc++fs
-    tirpc
+    ${TIRPC_LIBRARIES}
 )
 
 install(TARGETS VisIVOImporter DESTINATION bin)


### PR DESCRIPTION
Dear VisIVOServer team. This pull request aims at fixing an issue which might occur when compiling the VisIVOImporter component and API_LIGHT component. 

Before this PR, the library libtirpc-dev was included as a dependency without being searched by cmake before. This would normally not be an issue in normal systems, but when compiling on systems (such as supercomputers) that do not have the library installed by default, this poses an issue, especially when user space package manager (Such as space) are used. 

This pull request hence aims at fixing this issue, by making cmake first search the library and then include it. 
